### PR TITLE
Fix devId casing

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,14 +74,14 @@ yarn add event-notification-nodejs-sdk
    "SANDBOX": {
        "clientId": "<appid-from-developer-portal>",
        "clientSecret": "<certid-from-developer-portal>",
-       "devid": "<devid-from-developer-portal>",
+       "devId": "<devid-from-developer-portal>",
        "redirectUri": "<redirect_uri-from-developer-portal>",
        "baseUrl": "api.sandbox.ebay.com"
    },
    "PRODUCTION": {
        "clientId": "<appid-from-developer-portal>",
        "clientSecret": "<certid-from-developer-portal>",
-       "devid": "<devid-from-developer-portal>",
+       "devId": "<devid-from-developer-portal>",
        "redirectUri": "<redirect_uri-from-developer-portal>",
        "baseUrl": "api.ebay.com"
    },

--- a/examples/config.json
+++ b/examples/config.json
@@ -2,14 +2,14 @@
     "SANDBOX": {
         "clientId": "<appid-from-developer-portal>",
         "clientSecret": "<certid-from-developer-portal>",
-        "devid": "<devid-from-developer-portal>",
+        "devId": "<devid-from-developer-portal>",
         "redirectUri": "<redirect_uri-from-developer-portal>",
         "baseUrl": "api.sandbox.ebay.com"
     },
     "PRODUCTION": {
         "clientId": "<appid-from-developer-portal>",
         "clientSecret": "<certid-from-developer-portal>",
-        "devid": "<devid-from-developer-portal>",
+        "devId": "<devid-from-developer-portal>",
         "redirectUri": "<redirect_uri-from-developer-portal>",
         "baseUrl": "api.ebay.com"
     },

--- a/test/test.js
+++ b/test/test.js
@@ -43,14 +43,14 @@ const sampleConfig = {
     'SANDBOX': {
         'clientId': 'clientId',
         'clientSecret': 'clientSecret',
-        'devid': 'devid',
+        'devId': 'devId',
         'redirectUri': 'redirectUri',
         'baseUrl': 'api.sandbox.ebay.com'
     },
     'PRODUCTION': {
         'clientId': 'clientId',
         'clientSecret': 'clientSecret',
-        'devid': 'devid',
+        'devId': 'devId',
         'redirectUri': 'redirectUri',
         'baseUrl': 'api.ebay.com'
     }


### PR DESCRIPTION
Hey, just wanted to fix the `devId` casing to bring it in line with the casing convention of the other properties, e.g. `clientId`. I looked through the SDK and it doesn't seem like the `devid` property from the config is being checked anywhere in `index.js` yet, so there should be no backwards-compatibility breakages and it'd be a nice small thing to fix before it ends up getting used/accessed in the future. 

Hope this helps!