### PR TITLE
Remove logs from accountDeletionMessageProcessor

### DIFF
--- a/lib/processor/accountDeletionMessageProcessor.js
+++ b/lib/processor/accountDeletionMessageProcessor.js
@@ -25,10 +25,6 @@
  */
 const processInternal = (message) => {
     const data = message.notification.data;
-    // eslint-disable-next-line no-console
-    console.log(`\n==========================\nUser ID: ${data.userId}`);
-    // eslint-disable-next-line no-console
-    console.log(`Username: ${data.username}\n==========================\n`);
 };
 
 module.exports = { process: processInternal };


### PR DESCRIPTION
Logging in accountDeletionMessageProcessor.js pollutes the general application logs so it should be removed.